### PR TITLE
Add the option to perform destructive migrations without downtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+Gemfile.lock
 
 # YARD artifacts
 .yardoc

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'heroku'
+gem 'rspec'

--- a/Readme.md
+++ b/Readme.md
@@ -24,6 +24,16 @@ asset group from being bundled, giving us a nice speed boost.
 heroku config:add BUNDLE_WITHOUT="development:test:assets"
 ```
 
+
+## Migrations
+
+By default any safe migrations will run without any downtime. So adding a new
+column/table/index. If a migration file contains an unsafe keyword
+`remove_column`, `execute` as examples, a maintenance page will be used for a
+downtime deploy. If you would like to prevent this behavior, then you can add a
+`# safe` comment on the destructive line. This allows a zero downtime deploy
+even with destructive operations.
+
 ## Development
 
 ```bash
@@ -35,6 +45,11 @@ ln -s ~/path/to/heroku-deploy heroku-deploy
 ```
 
 This should allow you to test the plugin and use it locally.
+
+
+## Testing
+
+The tests can be run with `rspec spec`
 
 ## Contributing
 

--- a/lib/heroku/deploy/diff.rb
+++ b/lib/heroku/deploy/diff.rb
@@ -29,10 +29,28 @@ module Heroku::Deploy
     end
 
     def has_unsafe_migrations?
-      migrations_diff.match /change_column|change_table|drop_table|remove_column|remove_index|rename_column|execute/
+      migrations_diff.split("\n").any? do |line|
+        has_unsafe_keyword?(line) && has_no_safe_override?(line)
+      end
     end
 
     private
+
+    def has_unsafe_keyword?(line)
+      line.match(unsafe_migration_regexp)
+    end
+
+    def has_no_safe_override?(line)
+      !line.match(safe_override_regexp)
+    end
+
+    def unsafe_migration_regexp
+      /change_column|change_table|drop_table|remove_column|remove_index|rename_column|execute/
+    end
+
+    def safe_override_regexp
+      /#\s*safe/
+    end
 
     def migrations_diff
       diff %w(db/migrate)

--- a/spec/heroku/deploy/diff_spec.rb
+++ b/spec/heroku/deploy/diff_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+module Heroku::Deploy::Shell
+  def git(*args)
+    $diff_content
+  end
+end
+
+describe Heroku::Deploy::Diff do
+  let(:diff) { Heroku::Deploy::Diff.new(from, to) }
+  let(:from) { double }
+  let(:to)   { double }
+
+  describe '#has_unsafe_migrations?' do
+    context 'when there are only safe migrations' do
+      before { $diff_content = 'add_table add_column' }
+
+      it 'returns false' do
+        expect(diff).to_not have_unsafe_migrations
+      end
+    end
+
+    context 'when there are unsafe migrations' do
+      before { $diff_content = 'remove_column' }
+
+      it 'returns true' do
+        expect(diff).to have_unsafe_migrations
+      end
+    end
+
+    context 'when there are unsafe migrations that are explicidly marked as safe' do
+
+      it 'returns false' do
+        $diff_content = 'remove_column #safe'
+        expect(diff).to_not have_unsafe_migrations
+
+        $diff_content = 'remove_column # safe'
+        expect(diff).to_not have_unsafe_migrations
+      end
+    end
+
+    context 'when only some of the unsafe migrations are marked' do
+      before { $diff_content = "remove_column :foo #safe\nremove_column :blah" }
+
+      it 'returns true' do
+        expect(diff).to have_unsafe_migrations
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,9 @@
+require_relative '../init'
+
+RSpec.configure do |config|
+  config.treat_symbols_as_metadata_keys_with_true_values = true
+  config.run_all_when_everything_filtered = true
+  config.filter_run :focus
+
+  config.order = 'random'
+end


### PR DESCRIPTION
By default when we detect unsafe migrations we use maintenance mode to
ensure we don't run into issues with missing/renamed columns or tables.

Here I have added the ability to tag unsafe migrations with a `# safe`
comment to instruct the deploy to ignore the unsafe migrations and
perform a zero downtime deploy. The migration will be run before the
deploy just like our usual safe migrations.
