### PR TITLE
Remove deprecated RSpec config setting

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require_relative '../init'
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
The `config.treat_symbols_as_metadata_keys_with_true_values` setting is
deprecated and throws a noisy deprecation warning when tests are run.
